### PR TITLE
Replace break to continue when process layer

### DIFF
--- a/toolkits/model_checkpoints_convertor/qwen/checkpoint_reshaping_and_interoperability.py
+++ b/toolkits/model_checkpoints_convertor/qwen/checkpoint_reshaping_and_interoperability.py
@@ -539,7 +539,7 @@ def convert_checkpoint_from_transformers_to_megatron(args):
                 m = layer_re.match(layer_name)
                 # Stop if that's not a layer
                 if m is None:
-                    break
+                    continue
 
                 # The index of the layer.
                 _ = int(m.group(1))
@@ -830,7 +830,7 @@ def convert_checkpoint_from_megatron_to_transformers(args):
             m = layer_re.match(key)
             # Stop if that's not a layer
             if m is None:
-                break
+                continue
 
             # The index of the layer.
             layer_idx = int(m.group(1)) + pp_rank * num_layers


### PR DESCRIPTION
The order of layers in the model can be arbitrary. When processing the final_layernorm layer, it's sufficient to just continue, there's no need to break immediately. Or 
![image](https://github.com/alibaba/Pai-Megatron-Patch/assets/39551840/7ae79794-7273-483b-acab-380106f50c2f)
