### PR TITLE
[fixed] unexpected eos_token concatenation

### DIFF
--- a/megatron_patch/data/llama.py
+++ b/megatron_patch/data/llama.py
@@ -134,7 +134,7 @@ class LLamaRawDataset(torch.utils.data.Dataset):
             key = 'content'
 
         targets = [
-            f"{example}{self.tokenizer.eos_token}"
+            example + " " + self.tokenizer.eos_token
             for example in examples[key]
         ]
 


### PR DESCRIPTION
When adding the eos_token at the end, it is necessary to ensure that there is a space on the left.
Otherwise the tokenizer will encode the '</s>' as expected.