### PR TITLE
fix bug: when convert megatron to transformer, determine whether val …

### DIFF
--- a/toolkits/model_checkpoints_convertor/qwen/hf2megatron_qwen1.5.py
+++ b/toolkits/model_checkpoints_convertor/qwen/hf2megatron_qwen1.5.py
@@ -930,6 +930,8 @@ def convert_checkpoint_from_megatron_to_transformers(args):
             # import pdb
             # pdb.set_trace()
             if op_name + "." + weight_or_bias not in tensor_parallel_params_mg:
+                if val is None:
+                    continue                
                 params = val.to(dtype)
             else:
                 # import pdb


### PR DESCRIPTION
fix issue [#156](https://github.com/alibaba/Pai-Megatron-Patch/issues/156) . when convert megatron to transformer, if the val of megatron model parameter dict is None, for example, key is layers.0.self_attention.query_key_value._extra_state,  a AttributeError will be thrown, as shown below:

```
Traceback (most recent call last):
  File "/workspace/Pai-Megatron-Patch/toolkits/model_checkpoints_convertor/qwen/hf2megatron_qwen1.5.py", line 1128, in <module>
    main()
  File "/workspace/Pai-Megatron-Patch/toolkits/model_checkpoints_convertor/qwen/hf2megatron_qwen1.5.py", line 1122, in main
    convert_checkpoint_from_megatron_to_transformers(args)
  File "/workspace/Pai-Megatron-Patch/toolkits/model_checkpoints_convertor/qwen/hf2megatron_qwen1.5.py", line 937, in convert_checkpoint_from_megatron_to_transformers
    params = val.to(dtype)
AttributeError: 'NoneType' object has no attribute 'to'
```