### PR TITLE
Fix issues that example mcore models dont scale query value.

### DIFF
--- a/examples/deepseek_v2/run_finetune_deepseek.sh
+++ b/examples/deepseek_v2/run_finetune_deepseek.sh
@@ -136,7 +136,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/deepseek_v2/run_pretrain_deepseek.sh
+++ b/examples/deepseek_v2/run_pretrain_deepseek.sh
@@ -134,7 +134,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/llama2/run_evaluate_mcore_llama.sh
+++ b/examples/llama2/run_evaluate_mcore_llama.sh
@@ -85,7 +85,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/llama2/run_finetune_mcore_llama_withGA.sh
+++ b/examples/llama2/run_finetune_mcore_llama_withGA.sh
@@ -96,7 +96,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/llama2/run_pretrain_mcore_llama.sh
+++ b/examples/llama2/run_pretrain_mcore_llama.sh
@@ -95,7 +95,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/llama3/run_finetune_mcore_llama_withGA.sh
+++ b/examples/llama3/run_finetune_mcore_llama_withGA.sh
@@ -78,7 +78,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/llama3/run_pretrain_mcore_llama.sh
+++ b/examples/llama3/run_pretrain_mcore_llama.sh
@@ -76,7 +76,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/mistral/run_evaluate_mcore_mistral.sh
+++ b/examples/mistral/run_evaluate_mcore_mistral.sh
@@ -86,7 +86,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/mistral/run_finetune_mcore_mistral_withGA.sh
+++ b/examples/mistral/run_finetune_mcore_mistral_withGA.sh
@@ -82,7 +82,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/mistral/run_pretrain_mcore_mistral.sh
+++ b/examples/mistral/run_pretrain_mcore_mistral.sh
@@ -79,7 +79,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/qwen/run_evaluate_megatron_qwen_moe.sh
+++ b/examples/qwen/run_evaluate_megatron_qwen_moe.sh
@@ -95,7 +95,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/qwen/run_pretrain_megatron_qwen_upcycled.sh
+++ b/examples/qwen/run_pretrain_megatron_qwen_upcycled.sh
@@ -101,7 +101,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/qwen1_5/run_evaluate_mcore_qwen.sh
+++ b/examples/qwen1_5/run_evaluate_mcore_qwen.sh
@@ -98,7 +98,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/qwen1_5/run_finetune_mcore_qwen_withGA.sh
+++ b/examples/qwen1_5/run_finetune_mcore_qwen_withGA.sh
@@ -143,7 +143,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"

--- a/examples/qwen1_5/run_pretrain_mcore_qwen.sh
+++ b/examples/qwen1_5/run_pretrain_mcore_qwen.sh
@@ -140,7 +140,9 @@ fi
 
 if [ $PR = fp16 ]; then
     pr_options=" \
-		    --fp16"
+		    --fp16 \
+            --apply-query-key-layer-scaling"
+    export NVTE_APPLY_QK_LAYER_SCALING=1
 elif [ $PR = bf16 ]; then
     pr_options=" \
         --bf16"


### PR DESCRIPTION
There is argument behaviour change in latest megatron-lm repo as below:

In Megatron-LM-23*, qk factor is by default enabled which helps make training stable especially in fp16 case.

```
    group.add_argument('--no-query-key-layer-scaling', action='store_false',
                       help='Do not scale Q * K^T by 1 / layer-number.',
                       dest='apply_query_key_layer_scaling')
    group.add_argument('--attention-softmax-in-fp32', action='store_true',
                       help='Run attention masking and softmax in fp32. '
                       'This flag is ignored unless '
                       '--no-query-key-layer-scaling is specified.')
```

However, in Megatron-LM-24*, the argument is by default disabled and recommended to be enabled for fp16 training.
```
    group.add_argument('--apply-query-key-layer-scaling', action='store_true',
                       help='Scale Q * K^T by 1 / layer-number. '
                       'Useful for fp16 training.')
    group.add_argument('--attention-softmax-in-fp32', action='store_true',
                       help='Run attention masking and softmax in fp32. '
                       'This flag is ignored unless '
                       '--no-query-key-layer-scaling is specified.')
```
More evidence shown on Megatron-LM upstream testcase:
```
Megatron-LM/tests/functional_tests/test_scripts/gpt3/pretrain_gpt3_distributed_test.sh

       --${TRAINING_DTYPE}"

if [[ "${TRAINING_DTYPE}" == "fp16" ]]; then
    torch_run_cmd+=" --apply-query-key-layer-scaling"
fi
```
Above arguments hence lead to different training result. This patch is used to fix this behaviours. So if fp16 training is being launched, scale factor would take effect to avoid training instable.

