### PR TITLE
Update hf2mcore_deepseek_v3_moe.py

### DIFF
--- a/toolkits/model_checkpoints_convertor/deepseek/hf2mcore_deepseek_v3_moe.py
+++ b/toolkits/model_checkpoints_convertor/deepseek/hf2mcore_deepseek_v3_moe.py
@@ -501,7 +501,10 @@ def save_mgmodel(mgmodel, args):
                         else:
                             target_v = v
 
-                        if "embedding.word_embeddings" in k and "mtp_embedding" not in k:
+                        if 'experts' in k and 'shared_experts' not in k:
+                            if tp_rank == 0:
+                                model_split[k] = target_v
+                        elif "embedding.word_embeddings" in k and "mtp_embedding" not in k:
                             if pp_rank == 0:
                                 model_split[k] = target_v
                         elif "mtp_embedding.word_embeddings" in k:


### PR DESCRIPTION
When setting expert-tensor-parallel-size=1, the weights of routed-experts will be saved repeatly during different tp_rank. It will consume ~1.3T*${TP} disk space, it's too huge!!