### PR TITLE
Fix MEGATRON_PATCH_PATH in qwen2_5 run_8xH20.sh

### DIFF
--- a/toolkits/distributed_checkpoints_convertor/scripts/qwen2_5/run_8xH20.sh
+++ b/toolkits/distributed_checkpoints_convertor/scripts/qwen2_5/run_8xH20.sh
@@ -3,7 +3,7 @@ set -e
 CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 CONVERTOR_DIR=$( dirname $( dirname ${CURRENT_DIR}))
 MEGATRON_PATCH_PATH=$( dirname $( dirname ${CONVERTOR_DIR}))
-export PYTHONPATH=${MEGATRON_PATCH_PATH}:${MEGATRON_PATCH_PATH}/backends/megatron/Megatron-LM-250328:${CONVERTOR_DIR}/impl:$PYTHONPATH
+export PYTHONPATH=${MEGATRON_PATCH_PATH}:${MEGATRON_PATCH_PATH}/backends/megatron/Megatron-LM-250624:${CONVERTOR_DIR}/impl:$PYTHONPATH
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 export TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=true # for PyTorch >= 2.6
 


### PR DESCRIPTION
the previous backend will raise " TypeError: _write_item() missing 1 required positional argument: 'serialization_format' " , update to new compatible version.