### PR TITLE
Fix the combination of vision embeds and text embeds in qwen2vl

### DIFF
--- a/megatron_patch/model/qwen2_vl/language_model_embedding.py
+++ b/megatron_patch/model/qwen2_vl/language_model_embedding.py
@@ -141,14 +141,14 @@ class LanguageModelEmbedding(MegatronModule):
         if self.config.sequence_parallel:
             if not self.reduce_scatter_embeddings:
                 embeddings = embeddings.clone()
-                embeddings = embeddings.transpose(0, 1)
+                embeddings = embeddings.transpose(0, 1).contiguous()
                 if image_embeds is not None:
                     image_input_mask = image_input_mask.transpose(0,1).unsqueeze(-1).expand_as(embeddings)
                     embeddings = embeddings.masked_scatter(image_input_mask, image_embeds.to(embeddings.device, embeddings.dtype))
                 if video_embeds is not None:
                     video_input_mask = video_input_mask.transpose(0,1).unsqueeze(-1).expand_as(embeddings)
                     embeddings = embeddings.masked_scatter(video_input_mask, video_embeds.to(embeddings.device, embeddings.dtype))
-                embeddings = embeddings.transpose(0, 1)
+                embeddings = embeddings.transpose(0, 1).contiguous()
                 embeddings = tensor_parallel.scatter_to_sequence_parallel_region(embeddings)
             # `scatter_to_sequence_parallel_region` returns a view, which prevents
             # the original tensor from being garbage collected. Clone to facilitate GC.
@@ -160,7 +160,7 @@ class LanguageModelEmbedding(MegatronModule):
         else:
             embeddings = embeddings.clone()
             if not self.reduce_scatter_embeddings:
-                embeddings = embeddings.transpose(0, 1)
+                embeddings = embeddings.transpose(0, 1).contiguous()
             if image_embeds is not None:
                 image_input_mask = image_input_mask.transpose(0,1).unsqueeze(-1).expand_as(embeddings)
                 embeddings = embeddings.masked_scatter(image_input_mask, image_embeds.to(embeddings.device, embeddings.dtype))
@@ -168,7 +168,7 @@ class LanguageModelEmbedding(MegatronModule):
                 video_input_mask = video_input_mask.transpose(0,1).unsqueeze(-1).expand_as(embeddings)
                 embeddings = embeddings.masked_scatter(video_input_mask, video_embeds.to(embeddings.device, embeddings.dtype))
             if not self.reduce_scatter_embeddings:
-                embeddings = embeddings.transpose(0, 1)
+                embeddings = embeddings.transpose(0, 1).contiguous()
             embeddings = self.embedding_dropout(embeddings)
 
         return embeddings


### PR DESCRIPTION
## PR Description
As described in https://github.com/alibaba/Pai-Megatron-Patch/issues/647.

After aligning most of the configurations (including image mean/std, input format, multi-turn data processing, learning rate, optimizer, etc.) with frameworks like MS-Swift, I noticed that the results from fine-tuning with run_mcore_qwen.sh on the same dataset were consistently 3-5 percentage points lower.

To isolate the issue, I performed a layer-by-layer replacement of the TE layers and Megatron-Core's norm and linear implementations to align the forward pass with the standard Hugging Face Transformers implementation. This process allowed me to pinpoint the potential source of the problem to the line:
https://github.com/alibaba/Pai-Megatron-Patch/blob/ea0b65eef7219ccaa8de625219103dbaa4103345/megatron_patch/model/qwen2_vl/language_model_embedding.py#L159

The core issue is that performing this advanced indexing operation on the transposed embeddings tensor (Seq, Batch, Hidden) incorrectly maps the image_embeds to the masked positions. This effectively scrambles the image patch embeddings within the final input sequence. By reverting the tensor to the standard (Batch, Seq, Hidden) layout to align with the forward pass of the Transformers library, the combined embeddings are constructed correctly.

With the proposed code change, after training qwen2-vl-2b for one epoch on my dataset, the evaluation results are as follows:
| Metric | Baseline | Before Fix | After Fix |
| :--- | :--- | :--- | :--- |
| TextVQA-val | 79.9 | 75.6 | 80.5 |
| MMBench-v1.1 | 72.2 | 70.1 | 74.5 |

## Explanation of the Indexing Error
To illustrate why the indexing method fails on the transposed tensor, here is a minimal reproducible example:

Consider the following scenario:

Batch Size: 2.

Batch 0: Contains one image represented by 3 embedding vectors. To expose the issue, these are placed in the latter half of the sequence (e.g., at positions 4, 5, 6).

Batch 1: Contains one image represented by 2 embedding vectors. These are placed in the earlier half of the sequence (e.g., at positions 1, 2).

image_embeds tensor: Contains 3 + 2 = 5 vectors, ordered by batch. The first 3 vectors belong to Batch 0, and the next 2 belong to Batch 1.

We can run the script：
```python
import torch

# --- 1. Setup of the final, focused example ---
batch_size = 2
seq_len = 8
hidden_dim = 3

# Base embeddings tensor, format: (Seq, Batch, Hidden)
embeddings = torch.zeros(seq_len, batch_size, hidden_dim)

# --- Image Embeddings Setup ---
# This tensor concatenates all image patch embeddings, ordered by batch.
# Total patches = 3 (from batch 0) + 2 (from batch 1) = 5
image_embeds = torch.tensor([
    # --- Embeddings for Batch 0's image (3 patches) ---
    [111., 111., 111.], # Batch 0, Patch 1
    [222., 222., 222.], # Batch 0, Patch 2
    [333., 333., 333.], # Batch 0, Patch 3
    # --- Embeddings for Batch 1's image (2 patches) ---
    [444., 444., 444.], # Batch 1, Patch 1
    [555., 555., 555.]  # Batch 1, Patch 2
])

# Define the locations of the image tokens in (seq_idx, batch_idx) format.
# CRITICAL DESIGN: Batch 1's tokens appear at earlier sequence positions.
image_token_locations = [
    # Batch 0 locations (later in sequence)
    (4, 0), (5, 0), (6, 0),
    # Batch 1 locations (earlier in sequence)
    (1, 1), (2, 1)
]

print("--- Final, Focused Setup ---")
print(f"Batch size: {batch_size}, Seq length: {seq_len}")
print(f"Total image patch embeddings to insert (shape: {image_embeds.shape}):\n{image_embeds}\n")
print(f"Image token locations (seq_idx, batch_idx): {image_token_locations}\n")


# --- 2. Method 1: Advanced indexing on (Seq, Batch, Hidden) tensor ---
print("--- Method 1: Advanced Indexing on (Seq, Batch, Hidden) ---")
embeddings_m1 = embeddings.clone()

image_input_mask = torch.zeros(seq_len, batch_size, dtype=torch.bool)
for seq_idx, batch_idx in image_token_locations:
    image_input_mask[seq_idx, batch_idx] = True

# Traversal order finds Trues at (1,1), (2,1) first, then (4,0), (5,0), (6,0).
# This is the wrong order for filling from the batch-ordered `image_embeds`.
embeddings_m1[image_input_mask] = image_embeds

print("Result of Method 1 (shape: (Seq, Batch, Hidden)):")
# To make it easier to read, we permute and show each batch item's sequence
embeddings_m1_transposed = embeddings_m1.permute(1, 0, 2)
for b in range(batch_size):
    print(f"\nBatch {b} sequence from Method 1:")
    print(embeddings_m1_transposed[b, :, :])

print("\nAnalysis of Method 1:")
print(">>> FAILURE! Batch 1 (at seq pos 1, 2) received embeddings [111, 222], which belong to Batch 0.")
print(">>> Conversely, Batch 0 (at seq pos 4, 5, 6) received [333, 444, 555], mixing embeddings from both batches.")
print(">>> This is a direct result of the incorrect Seq-major traversal order.\n\n")


# --- 3. Method 2: masked_scatter on (Batch, Seq, Hidden) tensor ---
print("--- Method 2: masked_scatter on (Batch, Seq, Hidden) ---")
inputs_embeds_m2 = embeddings.permute(1, 0, 2).clone()
image_mask = torch.zeros_like(inputs_embeds_m2, dtype=torch.bool)
for seq_idx, batch_idx in image_token_locations:
    image_mask[batch_idx, seq_idx, :] = True

# The Batch-major traversal correctly processes all of Batch 0 first, then Batch 1.
inputs_embeds_m2.masked_scatter_(image_mask, image_embeds)

print("Result of Method 2 (shape: (Batch, Seq, Hidden)):")
for b in range(batch_size):
    print(f"\nBatch {b} sequence from Method 2:")
    print(inputs_embeds_m2[b, :, :])

print("\nAnalysis of Method 2:")
print(">>> CORRECT! Batch 0 correctly has [111, 222, 333] at sequence positions 4, 5, 6.")
print(">>> Batch 1 correctly has [444, 555] at sequence positions 1, 2.")
print(">>> The Batch-major processing order ensures data integrity within each sample.")
```
And we can get
```bash
--- Final, Focused Setup ---
Batch size: 2, Seq length: 8
Total image patch embeddings to insert (shape: torch.Size([5, 3])):
tensor([[111., 111., 111.],
        [222., 222., 222.],
        [333., 333., 333.],
        [444., 444., 444.],
        [555., 555., 555.]])

Image token locations (seq_idx, batch_idx): [(4, 0), (5, 0), (6, 0), (1, 1), (2, 1)]

--- Method 1: Advanced Indexing on (Seq, Batch, Hidden) ---
Result of Method 1 (shape: (Seq, Batch, Hidden)):

Batch 0 sequence from Method 1:
tensor([[  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [333., 333., 333.],
        [444., 444., 444.],
        [555., 555., 555.],
        [  0.,   0.,   0.]])

Batch 1 sequence from Method 1:
tensor([[  0.,   0.,   0.],
        [111., 111., 111.],
        [222., 222., 222.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.]])

Analysis of Method 1:
>>> FAILURE! Batch 1 (at seq pos 1, 2) received embeddings [111, 222], which belong to Batch 0.
>>> Conversely, Batch 0 (at seq pos 4, 5, 6) received [333, 444, 555], mixing embeddings from both batches.
>>> This is a direct result of the incorrect Seq-major traversal order.


--- Method 2: masked_scatter on (Batch, Seq, Hidden) ---
Result of Method 2 (shape: (Batch, Seq, Hidden)):

Batch 0 sequence from Method 2:
tensor([[  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [111., 111., 111.],
        [222., 222., 222.],
        [333., 333., 333.],
        [  0.,   0.,   0.]])

Batch 1 sequence from Method 2:
tensor([[  0.,   0.,   0.],
        [444., 444., 444.],
        [555., 555., 555.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.],
        [  0.,   0.,   0.]])

Analysis of Method 2:
>>> CORRECT! Batch 0 correctly has [111, 222, 333] at sequence positions 4, 5, 6.
>>> Batch 1 correctly has [444, 555] at sequence positions 1, 2.
>>> The Batch-major processing order ensures data integrity within each sample.
```

When the advanced indexing embeddings[mask] is applied to a tensor with a (Seq, Batch) layout, it scans sequence-first. It finds the True values in the mask at seq_pos=1 and seq_pos=2 (belonging to Batch 1) before it finds the True values at seq_pos=4 (belonging to Batch 0). As a result, it takes the first vectors from the image_embeds tensor (which belong to Batch 0) and incorrectly places them in the slots designated for Batch 1, leading to scrambled input.