### PR TITLE
fix error when convert qwen2.5_vl

### DIFF
--- a/toolkits/model_checkpoints_convertor/qwen/hf2mcore_qwen2.5_vl.py
+++ b/toolkits/model_checkpoints_convertor/qwen/hf2mcore_qwen2.5_vl.py
@@ -291,7 +291,7 @@ def convert_checkpoint_from_megatron_to_transformers(mgmodel, hfmodel, args):
     assert n_params == copied_numel
 
     # 3. llm [just Qwen2]
-    hfllm = hfmodel.model
+    hfllm = hfmodel.model.language_model
     mgllm = mgmodel.language_model
     copied_numel = 0
     copied_numel += safe_copy(mgllm.embedding.word_embeddings.weight, hfllm.embed_tokens.weight)
@@ -399,7 +399,7 @@ def convert_checkpoint_from_transformers_to_megatron(hfmodel, mgmodel, args):
     assert n_params == copied_numel
 
     # 3. llm [just Qwen2]
-    hfllm = hfmodel.model
+    hfllm = hfmodel.model.language_model
     mgllm = mgmodel.language_model
     copied_numel = 0
     copied_numel += safe_copy(hfllm.embed_tokens.weight, mgllm.embedding.word_embeddings.weight)


### PR DESCRIPTION
fix below error:

```
> building Qwen2Tokenizer tokenizer ...
start building qwen2-vl model ...
Multimodal RoPE currently not support RoPE interpolation, set to None...
building Qwen2-5-VL model in TE...
WARNING:megatron_patch.model.qwen2_5_vl.model:Qwen2VL model is under development and may be missing features.
[rank0]: Traceback (most recent call last):
[rank0]:   File "/root/code/Pai-Megatron-Patch/toolkits/model_checkpoints_convertor/qwen/hf2mcore_qwen2.5_vl.py", line 730, in <module>
[rank0]:     main()
[rank0]:   File "/root/miniconda3/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/root/code/Pai-Megatron-Patch/toolkits/model_checkpoints_convertor/qwen/hf2mcore_qwen2.5_vl.py", line 726, in main
[rank0]:     convert_checkpoint_from_transformers_to_megatron(hf_model, mg_model, args)
[rank0]:   File "/root/miniconda3/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/root/code/Pai-Megatron-Patch/toolkits/model_checkpoints_convertor/qwen/hf2mcore_qwen2.5_vl.py", line 405, in convert_checkpoint_from_transformers_to_megatron
[rank0]:     copied_numel += safe_copy(hfllm.embed_tokens.weight, mgllm.embedding.word_embeddings.weight)
[rank0]:   File "/root/miniconda3/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1928, in __getattr__
[rank0]:     raise AttributeError(
[rank0]: AttributeError: 'Qwen2_5_VLModel' object has no attribute 'embed_tokens'
```